### PR TITLE
Pass message to the Exception so getMessage does not return null

### DIFF
--- a/src/main/scala/sangria/relay/Connection.scala
+++ b/src/main/scala/sangria/relay/Connection.scala
@@ -226,4 +226,4 @@ object ConnectionArgs {
   val empty = ConnectionArgs()
 }
 
-case class ConnectionArgumentValidationError(message: String) extends Exception with UserFacingError
+case class ConnectionArgumentValidationError(message: String) extends Exception(message) with UserFacingError


### PR DESCRIPTION
If the message is not passed to the `Exception`, the `getMessage` method will return `null`. This is a problem since the [ResultResolver](https://github.com/sangria-graphql-org/sangria/blob/master/modules/core/src/main/scala/sangria/execution/ResultResolver.scala#L148) uses it  to render the user facing error. Since `null` is returned there in the end it will blow up with an internal server error.

